### PR TITLE
Wrapped BP_VERSION check in bp_include action

### DIFF
--- a/loader.php
+++ b/loader.php
@@ -1,14 +1,14 @@
 <?php
 /*
 Plugin Name: Buddypress Notifications Manager
-Plugin URI: 
+Plugin URI:
 Description: Buddypress Notifications Manager : Manage the Buddypress Email Notifcations Settings for all users in One screen!.
 Version: 1.0
 Requires at least: Example: WP 3.2.1, BuddyPress 1.5
 Tested up to: BuddyPress 1.5
 License: GNU General Public License 2.0 (GPL) http://www.gnu.org/licenses/gpl.html
 Author: Meg@Info
-Author URI: http://profiles.wordpress.org/megainfo 
+Author URI: http://profiles.wordpress.org/megainfo
 Network: true
 */
 
@@ -60,8 +60,8 @@ function bp_notifications_manager() {
 	bp_notifications_manager_admin();
 }
 
-/** 
- * add bp Notifications manager link in Buddypress Menu 
+/**
+ * add bp Notifications manager link in Buddypress Menu
  */
 function bp_notifications_manager_admin_actions() {
 	//add_options_page("Buddypress Notifications Manager", "Notifications Manager", 1, "bp_notifications_manager_admin", "bp_notifications_manager");
@@ -69,12 +69,12 @@ function bp_notifications_manager_admin_actions() {
 }
 add_action('admin_menu', 'bp_notifications_manager_admin_actions');
 
-/** 
- * Update(Add) the notifcations meta data when user activate 
+/**
+ * Update(Add) the notifcations meta data when user activate
  * his account
  **/
-function bp_notifications_manager_activated_user( $user_id, $key, $user ) {	
-	$notifications = unserialize( get_option('bp_notifications') ); 
+function bp_notifications_manager_activated_user( $user_id, $key, $user ) {
+	$notifications = unserialize( get_option('bp_notifications') );
 	if( isset($notifications) ){
 		foreach ( (array)$notifications as $key => $value ) {
 			//update_user_meta($user_id, $key, $value );
@@ -85,7 +85,7 @@ function bp_notifications_manager_activated_user( $user_id, $key, $user ) {
 }
 add_filter( 'bp_core_activated_user', 'bp_notifications_manager_activated_user', 1, 3);
 
-/** 
+/**
  * Hide Notification subnav item and menu element and all acces
  * to notifications settings page if bp_notifications_manager_disabled is yes
  */
@@ -96,12 +96,12 @@ function bp_notifications_manager_subnav(){
 		//if( !is_site_admin() ){ // this work only for bp 1.6 ( so i use  !current_user_can('manage_options') to check if is admin user)
 		if( !current_user_can('manage_options')	){
 			bp_core_remove_subnav_item($bp->settings->slug, 'notifications');
-			
-			//bp_core_remove_nav_item( $bp->settings->slug, 'notifications' );	
+
+			//bp_core_remove_nav_item( $bp->settings->slug, 'notifications' );
 			// //remove notifcation subnav item and notification link for adminbar
 			//bp_core_remove_subnav_item($bp->settings->slug, 'notifications');
 			//remove_action( 'bp_adminbar_menus', 'bp_adminbar_notifications_menu', 8 );
-			
+
 			// remove notification setting link from wp adminbar if is bp use it
 			if ( bp_use_wp_admin_bar() ) {
 				$bp->temp_slug = $slug;
@@ -113,12 +113,15 @@ function bp_notifications_manager_subnav(){
 	}
 }
 
-//if is not bp 1.5
-if (  version_compare( BP_VERSION, '1.5' ) < 0 ) 
-	add_action( 'wp', 'bp_notifications_manager_subnav');
-else
-	add_action( 'bp_setup_nav', 'bp_notifications_manager_subnav' );
+function bp_notifications_manager_initialize() {
+	//if is not bp 1.5
+	if ( version_compare( BP_VERSION, '1.5' ) < 0 )
+		add_action( 'wp', 'bp_notifications_manager_subnav');
+	else
+		add_action( 'bp_setup_nav', 'bp_notifications_manager_subnav' );
 
-// load text domain for the plugin
-if ( file_exists( BP_NOTIFICATIONS_MANAGER_PLUGIN_DIR . '/languages/' . get_locale() . '.mo' ) )
-	load_textdomain( 'bp-notifs-manager', BP_NOTIFICATIONS_MANAGER_PLUGIN_DIR . '/languages/' . get_locale() . '.mo' );
+	// load text domain for the plugin
+	if ( file_exists( BP_NOTIFICATIONS_MANAGER_PLUGIN_DIR . '/languages/' . get_locale() . '.mo' ) )
+		load_textdomain( 'bp-notifs-manager', BP_NOTIFICATIONS_MANAGER_PLUGIN_DIR . '/languages/' . get_locale() . '.mo' );
+}
+add_action( 'bp_include', 'bp_notifications_manager_initialize' );


### PR DESCRIPTION
Hello @messaoudi-mounir, wasn't sure if this repo was being used for the plugin but wanted to prompt an update to utilize the appropriate mechanism for initializing a BuddyPress plugin using the bp_include so as to avoid the BP_VERSION constant being undefined.
Referencing Wordpress Support Ticket - https://wordpress.org/support/topic/resolution-for-bp_version-issue?replies=1#post-7969871
